### PR TITLE
Fix entity renderer registration

### DIFF
--- a/src/main/java/example/examplemod/client/ExampleEntityRenderer.java
+++ b/src/main/java/example/examplemod/client/ExampleEntityRenderer.java
@@ -1,0 +1,26 @@
+package example.examplemod.client;
+
+import example.examplemod.entity.ExampleEntity;
+import net.minecraft.client.model.HumanoidModel;
+import net.minecraft.client.model.geom.ModelLayers;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.client.renderer.entity.MobRenderer;
+import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
+import net.minecraft.resources.ResourceLocation;
+
+public class ExampleEntityRenderer extends MobRenderer<ExampleEntity, HumanoidModel<ExampleEntity>> {
+    private static final ResourceLocation TEXTURE = new ResourceLocation("minecraft", "textures/entity/zombie/zombie.png");
+
+    public ExampleEntityRenderer(EntityRendererProvider.Context context) {
+        super(context, new HumanoidModel<>(context.bakeLayer(ModelLayers.ZOMBIE)), 0.5f);
+        this.addLayer(new HumanoidArmorLayer<>(this,
+                new HumanoidModel<>(context.bakeLayer(ModelLayers.ZOMBIE_INNER_ARMOR)),
+                new HumanoidModel<>(context.bakeLayer(ModelLayers.ZOMBIE_OUTER_ARMOR)),
+                context.getModelManager()));
+    }
+
+    @Override
+    public ResourceLocation getTextureLocation(ExampleEntity entity) {
+        return TEXTURE;
+    }
+}

--- a/src/main/java/example/examplemod/client/ExampleModClient.java
+++ b/src/main/java/example/examplemod/client/ExampleModClient.java
@@ -1,0 +1,16 @@
+package example.examplemod.client;
+
+import example.examplemod.ExampleMod;
+import example.examplemod.registry.ModEntities;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.EntityRenderersEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(modid = ExampleMod.MODID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+public class ExampleModClient {
+    @SubscribeEvent
+    public static void registerRenderers(EntityRenderersEvent.RegisterRenderers event) {
+        event.registerEntityRenderer(ModEntities.EXAMPLE_ENTITY.get(), ExampleEntityRenderer::new);
+    }
+}


### PR DESCRIPTION
## Summary
- add a renderer for `ExampleEntity`
- register the renderer on the client side

## Testing
- `./gradlew --version` *(fails: Unable to download Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_6874aa3e1ee88321b78da8540f74922e